### PR TITLE
Fixed `:` and `>` showing incorrect values

### DIFF
--- a/guide/begin/character-escaping.md
+++ b/guide/begin/character-escaping.md
@@ -14,9 +14,11 @@ description: >-
 
 `;` =&gt; `#SEMI#` 
 
+`:` =&gt; `#COLON#` 
+
 `$` =&gt; `#CHAR#`
 
-`:` =&gt; `#RIGHT_CLICK#` 
+`>` =&gt; `#RIGHT_CLICK#`
 
 `<` =&gt; `#LEFT_CLICK#` 
 
@@ -25,8 +27,6 @@ description: >-
 `}` =&gt; `#LEFT_BRACKET#` 
 
 `{` =&gt; `#RIGHT_BRACKET#` 
-
-`:` =&gt; `#COLON#` 
 
 #### more:
 


### PR DESCRIPTION
There's no much to it, just that, saw it by error while trying to remember how chars are escaped