### PR TITLE
$stringStartsWith 2nd example typo fix

### DIFF
--- a/functions/usdstringstartswith.md
+++ b/functions/usdstringstartswith.md
@@ -25,7 +25,7 @@ $stringStartsWith[Hey, how are you?;Hey] // returns true
 bot.command({
     name: "startswith",
     code: `Does \`Hey, how are you?\` start with Hello?
-$stringStartsWith[Hey, how are you?;Hey] // returns false
+$stringStartsWith[Hey, how are you?;Hello] // returns false
     `
 });
 ```


### PR DESCRIPTION
Changed the second field of $stringStartsWith in the second example from `Hey` to `Hello`