### PR TITLE
Correction of a mistake.

### DIFF
--- a/functions/usdsenddm.md
+++ b/functions/usdsenddm.md
@@ -7,7 +7,7 @@ description: Sends a dm to the given user ID with the given message
 This function sends a dm to the specified user with &lt;message&gt;
 
 ```text
-$sendMessage[user ID;message]
+$sendDM[user ID;message]
 ```
 
 ```javascript


### PR DESCRIPTION
The documentation had an error. It said "sendMessage" and it should be "sendDM".